### PR TITLE
Fix CamelCase

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
                   </section>
               </li>
               <li class="nav-item">
-                  <a class="nav-link text-white" href="https://github.com/smlisk0630" target="_blank">Github</a>
+                  <a class="nav-link text-white" href="https://github.com/smlisk0630" target="_blank">GitHub</a>
               </li>
               <li class="nav-item">
                   <a class="nav-link text-white" href="https://www.linkedin.com/in/samanthalisk/" target="_blank">LinkedIn</a>


### PR DESCRIPTION
The name "GitHub" is pronounced more like "got ham" than like "Gotham", (i.e. [/ɡɨtħɐb/](http://ipa-reader.xyz/?text=%C9%A1%C9%A8t%C4%A7%C9%90b) instead of [/ɡɨθɐb/](http://ipa-reader.xyz/?text=%C9%A1%C9%A8%CE%B8%C9%90b)) and should therefore always be written with an upper-case "H".